### PR TITLE
default fromをsingle senderと統一させた

### DIFF
--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,4 +1,4 @@
 class ApplicationMailer < ActionMailer::Base
-  default from: "noreply@example.com"
+  default from: "sumigokochi2020@gmail.com"
   layout 'mailer'
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -12,12 +12,10 @@ Rails.application.configure do
   ActionMailer::Base.smtp_settings = {
     :address        => 'smtp.sendgrid.net',
     :port           => 587,
-    :authentication => :plain,
-      # :user_name      => Rails.application.credentials.dig(:sendgrid,:user_name),
-      # :password       => Rails.application.credentials.dig(:sendgrid,:password),
     :user_name      => 'apikey',
     :password       => Rails.application.credentials.dig(:sendgrid,:api_key),
     :domain         => 'heroku.com',
+    :authentication => :plain,
     :enable_starttls_auto =>true
   }
   # MailGun用の設定


### PR DESCRIPTION
```
Net::SMTPFatalError (550 The from address does not match a verified Sender Identity. Mail cannot be sent until this error is resolved. Visit https://sendgrid.com/docs/for-developers/sending-email/sender-identity/ to see the Sender Identity requirements)
```
上記のエラーを解消するために、**Single Sender**に`sumigokochi2020@gmail.com`を登録して、メールのdefault fromを変更した。